### PR TITLE
adds global parameter to disable on export

### DIFF
--- a/Obfuscator.glyphsFilter/Contents/Info.plist
+++ b/Obfuscator.glyphsFilter/Contents/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleName</key>
 	<string>Obfuscator</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>3.0.1</string>
 	<key>UpdateFeedURL</key>
 	<string>https://raw.githubusercontent.com/guidoferreyra/Obfuscator/master/Obfuscator.glyphsFilter/Contents/Info.plist</string>
 	<key>productPageURL</key>

--- a/Obfuscator.glyphsFilter/Contents/Resources/plugin.py
+++ b/Obfuscator.glyphsFilter/Contents/Resources/plugin.py
@@ -49,6 +49,8 @@ class Obfuscator(FilterWithoutDialog):
 
 	@objc.python_method
 	def filter(self, layer, inEditView, customParameters):
+		if layer.master.font.customParameters['obfuscatorDisabled'] == 'True':
+			return None
 
 		if len(customParameters) !=0:
 			character = customParameters['char']


### PR DESCRIPTION
Not sure if this is worth merging into the main repo, or if there's a better way to do it, but just in case you think it's useful:

**Use case**
* I use Obfuscator to generate trial files.
* I have fonts with many instances, and release new versions of each a few times a year. 
* I'd like to be able to generate both the full version and trial files with the same Glyphs file, to ensure everything is up to date.
* Currently, I have to save a new file and re-add the Obfuscator filter parameter to the instances whenever I'd like to generate a trial file. This also means I have to keep an old trial Glyphs file handy to copy the parameter with the glyph list and settings from.

**What this does**
* You can set a custom parameter of `obfuscatorDisabled` to `True` in the `Font` tab in font info.
* If `True`, it will ignore Obfuscator, and generate the full version. If the parameter is missing, or is set to anything else, Obfuscator will run as usual.